### PR TITLE
Update Krita.download.recipe regex

### DIFF
--- a/Krita/Krita.download.recipe
+++ b/Krita/Krita.download.recipe
@@ -27,7 +27,7 @@
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
                 <key>re_pattern</key>
-                <string>href=(https://download\.kde\.org/stable/krita/([0-9]+(\.[0-9]+)+)/krita-([0-9]+(\.[0-9]+)+)-signed\.dmg)</string>
+                <string>href=(https://download\.kde\.org/stable/krita/([0-9]+(\.[0-9]+)+)/krita-([0-9]+(\.[0-9]+)+)-release\.dmg)</string>
                 <key>request_headers</key>
                 <dict>
                     <key>user-agent</key>


### PR DESCRIPTION
The release name seems to have changed to include the word release. This change allows the Krita.download recipe to succeed